### PR TITLE
Add ODC version CLI parameter to allow version pinning

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ program
   .allowUnknownOption()
   .option('-o, --out <path>', 'the folder to write reports to', './dependency-check-reports')
   .option('--bin <path>', 'directory to which the dependency-check CLI will be installed', './dependency-check-bin')
-  .option('--force-install', 'install the dependency-check CLI even if there already is one (will be overwritten)');
+  .option('--force-install', 'install the dependency-check CLI even if there already is one (will be overwritten)')
+  .option('--odc-version <version>', 'the version of the dependency-check CLI to install in format "v1.2.3" or "latest"', 'latest');
 
   program.addHelpText('after', `
 You can also use any arguments supported by the Owasp Dependency Check CLI tool, see: https://jeremylong.github.io/DependencyCheck/dependency-check-cli/arguments.html

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,10 +11,11 @@ const extract = require('extract-zip');
 
 const IS_WIN = os.platform() === 'win32';
 const NAME_RE = /^dependency\-check\-\d\.\d\.\d\-release\.zip$/;
-const RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/latest';
+const LATEST_RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/latest';
+const TAG_RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/tags/'; 
 
 function getBinDir() {
-  return path.resolve(process.cwd(), program.opts().bin);
+  return path.resolve(process.cwd(), program.opts().bin, program.opts().odcVersion);
 }
 
 function getCmdArguments() {
@@ -69,7 +70,9 @@ async function install() {
 
   cleanDir(binDir);
 
-  const res = await fetch(RELEASE_URL);
+  // if odc version is latest use latest URL, otherwise use version URL
+  const url = program.opts().odcVersion === 'latest' ? LATEST_RELEASE_URL : TAG_RELEASE_URL + program.opts().odcVersion;
+  const res = await fetch(url);
   const json = await res.json();
 
   const asset = json.assets.find(a => NAME_RE.test(a.name));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owasp-dependency-check",
-  "version": "0.0.22",
+  "version": "0.0.21",
   "description": "A Node.js wrapper for the CLI version of OWASP dependency-check tool.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owasp-dependency-check",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A Node.js wrapper for the CLI version of OWASP dependency-check tool.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a new CLI option to allow user to specify the version of the ODC so the version does not move on them unexpectedly.  This PR addresses https://github.com/etnetera/owasp-dependency-check/issues/19 which came about when ODC recently jumped to `9.0` and our scans broke since `9.0` is not backwards compatible with `8.x` and there was easy way to prevent the new version from being used.

The change allows for local caching of each version so is user specifies `v9.0.2` followed by `v9.0.4` and then goes back to `v9.0.2`, both versions will be retained locally and reused if needed.