### PR TITLE
fix: folder creation on new version download

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,7 @@ async function cleanDir(dir) {
     return;
   }
 
-  await mkdir(dir);
+  await mkdir(dir, { recursive: true });
 }
 
 function isReady() {


### PR DESCRIPTION
Fixes: https://github.com/etnetera/owasp-dependency-check/issues/28


PS: wasn't sure if I should also bump version in the `package.json`

