### PR TITLE
Update links to moved dependency-checker-cli repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > ⚠️ Requires **Node.js** version 14 or greater.
 
-Node.js wrapper for the [OWASP depencency-check CLI tool](https://jeremylong.github.io/DependencyCheck/dependency-check-cli/index.html).
+Node.js wrapper for the [OWASP depencency-check CLI tool](https://dependency-check.github.io/DependencyCheck/).
 
 ```
 npm install -D owasp-dependency-check
@@ -29,7 +29,7 @@ The easiest way is to add a new NPM script to your `package.json`, for example:
 
 ### Owasp Dependency Core options
 
-You can specify any options which the [OWASP depencency-check CLI tool](https://jeremylong.github.io/DependencyCheck/dependency-check-cli/index.html) provides. For example, to generate a HTML and JSON report, use:
+You can specify any options which the [OWASP depencency-check CLI tool](https://dependency-check.github.io/DependencyCheck/) provides. For example, to generate a HTML and JSON report, use:
 
 ```
 "scripts": {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,8 +11,8 @@ const extract = require('extract-zip');
 
 const IS_WIN = os.platform() === 'win32';
 const NAME_RE = /^dependency\-check\-\d+\.\d+\.\d+\-release\.zip$/;
-const LATEST_RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/latest';
-const TAG_RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/tags/';
+const LATEST_RELEASE_URL = 'https://api.github.com/repos/dependency-check/DependencyCheck/releases/latest';
+const TAG_RELEASE_URL = 'https://api.github.com/repos/dependency-check/DependencyCheck/releases/tags/';
 
 const LOG_FILE_NAME = 'dependency-check.log';
 


### PR DESCRIPTION
In February 2025 the original repository https://github.com/jeremylong/DependencyCheck was archived and moved to https://github.com/dependency-check/DependencyCheck.

This PR updates the relevant documentation and download links.

fixes #31