### PR TITLE
Implement spawn to execute evaluation

### DIFF
--- a/lib/dependency-check.js
+++ b/lib/dependency-check.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const { exec } = require('child_process');
+const spawn = require('cross-spawn');
 const { program } = require('commander');
 const colors = require('colors');
 const { getBinDir, cleanDir, getCmdArguments, log, getExecutable, isReady, install } = require('./utils');
@@ -8,35 +9,39 @@ const { getBinDir, cleanDir, getCmdArguments, log, getExecutable, isReady, insta
 function runCheck(executable) {
   cleanDir(path.resolve(process.cwd(), program.opts().out));
 
-  const opts = {
+  const execOpts = {
     cwd: path.resolve(process.cwd()),
     maxBuffer: 1024 * 1024 * 50,
   };
 
-  const cmdVersion = `${executable} --version`;
-  const cmd = `${executable} ${getCmdArguments()}`;
+  const spawnOpts = {
+    cwd: path.resolve(process.cwd()),
+    shell: false,
+    stdio: 'inherit'
+  };
 
-  exec(cmdVersion, opts, (err, _stdout, _stderr) => {
+  const cmdVersion = `${executable} --version`;
+  const cmdArguments = getCmdArguments();
+  const cmd = `${executable} ${cmdArguments.join(' ')}`;
+
+  exec(cmdVersion, execOpts, (err, _stdout, _stderr) => {
     if (err || _stderr) {
       console.error(err || _stderr);
       return;
     }
 
     const versionMatch = _stdout.match(/[^\d]* (\d+\.\d+\.\d+).*/);
-    
+
     log('Dependency-Check Core path:', executable);
     log('Dependency-Check Core version:', versionMatch ? versionMatch[1] : _stdout);
 
     log('Running command:\n', cmd);
-    exec(cmd, opts, (err, _stdout, _stderr) => {
-      if (err || _stderr) {
-        console.error(err || _stderr);
-        return;
-      }
 
+    const exececutableSpawn = spawn(executable, cmdArguments, spawnOpts);
+    exececutableSpawn.on('close', () => {
       log('Done.'.green);
-    })
-  })
+    });
+  });
 }
 
 async function run() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,7 @@ function getCmdArguments() {
     args.push('--scan=package-lock.json');
   }
 
-  return args.join(' ');
+  return args;
 }
 
 function getExecutable() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "owasp-dependency-check",
-  "version": "1.0.0",
+  "version": "0.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "owasp-dependency-check",
-      "version": "1.0.0",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",
         "commander": "^9.3.0",
+        "cross-spawn": "^7.0.6",
         "extract-zip": "^2.0.1",
         "node-fetch": "^2.6.7",
         "nodejs-file-downloader": "^4.9.3",
@@ -18,6 +19,9 @@
       },
       "bin": {
         "owasp-dependency-check": "index.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/node": {
@@ -88,6 +92,20 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -223,6 +241,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -304,6 +328,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -340,6 +373,27 @@
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -370,6 +424,21 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrappy": {
@@ -444,6 +513,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -534,6 +613,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -592,6 +676,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -621,6 +710,19 @@
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "tr46": {
       "version": "0.0.3",
@@ -652,6 +754,14 @@
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "colors": "^1.4.0",
     "commander": "^9.3.0",
+    "cross-spawn": "^7.0.6",
     "extract-zip": "^2.0.1",
     "node-fetch": "^2.6.7",
     "nodejs-file-downloader": "^4.9.3",


### PR DESCRIPTION
Closes https://github.com/etnetera/owasp-dependency-check/issues/30

### Validations

- ✅ Run `npm test`
- ✅ Tested with another project

### Additional notes

- `exec` is similar to `spawn` with `shell: true` option. However, that is [not recommended](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2)
- [cross-spawn](https://www.npmjs.com/package/cross-spawn) was included because `spawn` + `shell: false` fails in Windows with `spawn EINVAL`. `cross-spawn` helps with this issue.
- `package-lock.json` seems to be "desync" with `package.json` (it even have a wrong version). Let me know if I should remove it from the PR.
- I only switch one of the 2 `exec`. The first one is "fine" because it is "quickly enough" (let me know if full migration is desired).